### PR TITLE
Fix CPU usage storage error in system metrics scheduler

### DIFF
--- a/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/statistics/StatisticsCommand.java
+++ b/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/statistics/StatisticsCommand.java
@@ -55,9 +55,6 @@ public class StatisticsCommand {
    * @param diskUsagePercent   disk usage percentage
    */
   public void storeSystemMetrics(double cpuUsagePercent, double memoryUsagePercent, double diskUsagePercent) {
-    if (Double.isNaN(cpuUsagePercent) || Double.isNaN(memoryUsagePercent) || Double.isNaN(diskUsagePercent)) {
-      throw new IllegalArgumentException("percentage must be a number");
-    }
 
     if (cpuUsagePercent < 0 || cpuUsagePercent > 100) {
       throw new IllegalArgumentException("CPU usage percentage must be between 0 and 100");

--- a/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/statistics/SystemUsageMetrics.java
+++ b/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/statistics/SystemUsageMetrics.java
@@ -39,7 +39,7 @@ public interface SystemUsageMetrics {
   /**
    * Retrieves the current system CPU usage as a percentage.
    *
-   * @return the system CPU usage as a percentage, or null if not available
+   * @return the system CPU usage as a percentage, or 0.0 if not available
    */
   Double systemCpuUsagePercent();
 

--- a/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/statistics/SystemUsageMonitor.java
+++ b/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/statistics/SystemUsageMonitor.java
@@ -33,9 +33,12 @@ public class SystemUsageMonitor implements SystemUsageMetrics {
   public Double systemCpuUsagePercent() {
     OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
     if (osBean instanceof com.sun.management.OperatingSystemMXBean operatingSystemMXBean) {
-      return formatDouble(operatingSystemMXBean.getCpuLoad() * 100);
+      double cpuLoad = operatingSystemMXBean.getCpuLoad();
+      if (!Double.isNaN(cpuLoad) && cpuLoad >= 0.0 && cpuLoad <= 1.0) {
+        return formatDouble(cpuLoad * 100);
+      }
     }
-    return null;
+    return 0.0;
   }
 
   @Override

--- a/springdog-project/springdog-manager/src/test/java/org/easypeelsecurity/springdog/manager/statistics/StatisticsCommandTest.java
+++ b/springdog-project/springdog-manager/src/test/java/org/easypeelsecurity/springdog/manager/statistics/StatisticsCommandTest.java
@@ -78,7 +78,7 @@ class StatisticsCommandTest {
     // given invalid values
     double invalidCpuUsage = -10.0;
     double invalidMemoryUsage = 110.0;
-    double invalidDiskUsage = Double.NaN;
+    double invalidDiskUsage = -100.0;
 
     // when & then
     assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
Occasionally, CPU usage data is not collected. Modified the system to store the failed attempts without throwing exceptions.