### PR TITLE
Trigger change event on select2 initialization for already selected options

### DIFF
--- a/springdog-project/springdog-agent/src/main/resources/templates/content/rate-limit/actions/setting.html
+++ b/springdog-project/springdog-agent/src/main/resources/templates/content/rate-limit/actions/setting.html
@@ -118,7 +118,7 @@
       }).on("change", function () {
         const selectedData = $(this).select2("data");
         paramEnableInput.value = selectedData.map(item => item.element.dataset.name).join(",");
-      });
+      }).trigger('change');
     });
   </script>
 </head>


### PR DESCRIPTION
- Added trigger('change') to the #parametersOption select2 initialization to ensure the change event is triggered for already selected options
- Ensures the parameterNamesToEnable hidden input is correctly populated with the initial selection