### PR TITLE
Apply Flyway database migration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ mockitoVersion=5.8.0
 javapoetVersion=1.13.0
 jacocoVersion=0.8.7
 thymeleafLayoutDialectVersion=3.1.0
-derbyVersion=10.16.1.1
+derbyVersion=10.15.2.0
 cayenneVersion=4.2.1
 caffeineVersion=3.1.8
 snakeyamlVersion=2.2
@@ -23,6 +23,7 @@ asmVersion=9.7
 awaitilityVersion=4.2.1
 jsoupVersion=1.18.1
 htmlunitVersion=4.4.0
+flywayVersion=10.17.1
 # For deploy to maven central
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_CONNECT_TIMEOUT_SECONDS=300

--- a/springdog-project/springdog-autoconfigure/build.gradle
+++ b/springdog-project/springdog-autoconfigure/build.gradle
@@ -19,10 +19,16 @@ dependencies {
 
     implementation "org.ow2.asm:asm:${asmVersion}"
     implementation "org.ow2.asm:asm-commons:${asmVersion}"
+    implementation "org.flywaydb:flyway-core:${flywayVersion}"
+    runtimeOnly "org.flywaydb:flyway-database-derby:${flywayVersion}"
 
     compileOnly project(":springdog-project:springdog-agent")
     compileOnly project(":springdog-project:springdog-manager")
     implementation project(":springdog-project:springdog-shared")
+
+    implementation("org.apache.cayenne:cayenne-server:${cayenneVersion}") {
+        exclude group: 'org.slf4j', module: 'slf4j'
+    }
 
     testImplementation project(":springdog-project:springdog-shared")
     testImplementation project(":springdog-project:springdog-manager")

--- a/springdog-project/springdog-autoconfigure/src/main/java/org/easypeelsecurity/springdog/autoconfigure/datasource/package-info.java
+++ b/springdog-project/springdog-autoconfigure/src/main/java/org/easypeelsecurity/springdog/autoconfigure/datasource/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes for configuring Springdog datasource.
+ */
+
+package org.easypeelsecurity.springdog.autoconfigure.datasource;

--- a/springdog-project/springdog-autoconfigure/src/main/resources/springdog/db/migration/V1__Init_Database.sql
+++ b/springdog-project/springdog-autoconfigure/src/main/resources/springdog/db/migration/V1__Init_Database.sql
@@ -1,0 +1,71 @@
+create table APP.ENDPOINT
+(
+    HTTPMETHOD             VARCHAR(10)  not null,
+    ID                     BIGINT       not null
+        primary key,
+    ISPATTERNPATH          BOOLEAN      not null,
+    METHOD_SIGNATURE       VARCHAR(255) not null,
+    PATH                   VARCHAR(255) not null,
+    RULEBANTIMEINSECONDS   INTEGER      not null,
+    RULEIPBASED            BOOLEAN      not null,
+    RULEPERMANENTBAN       BOOLEAN      not null,
+    RULEREQUESTLIMITCOUNT  INTEGER      not null,
+    RULESTATUS             VARCHAR(255) not null,
+    RULETIMELIMITINSECONDS INTEGER      not null
+);
+
+create table APP.ENDPOINTPARAMETER
+(
+    ENABLED     BOOLEAN      not null,
+    ENDPOINT_ID BIGINT
+        references APP.ENDPOINT,
+    ID          BIGINT default GENERATED_BY_DEFAULT generated always as identity
+        primary key,
+    NAME        VARCHAR(255) not null,
+    TYPE        VARCHAR(255) not null
+);
+
+create table APP.ENDPOINTVERSIONCONTROL
+(
+    DATEOFVERSION       TIMESTAMP   not null
+        primary key,
+    FULLHASHOFENDPOINTS VARCHAR(64) not null,
+    ID                  BIGINT      not null
+);
+
+create table APP.ENDPOINTCHANGELOG
+(
+    CHANGETYPE              VARCHAR(255) not null,
+    DETAILSTRING            VARCHAR(255),
+    ID                      BIGINT       not null
+        primary key,
+    ISRESOLVED              BOOLEAN      not null,
+    REFLECTED_VERSION       TIMESTAMP    not null
+        references APP.ENDPOINTVERSIONCONTROL,
+    TARGETMETHOD            VARCHAR(30)  not null,
+    TARGETPATH              VARCHAR(255) not null,
+    TARGET_METHOD_SIGNATURE VARCHAR(255) not null
+);
+
+create table APP.ENDPOINT_METRIC
+(
+    AVERAGE_RESPONSE_MS    BIGINT not null,
+    ENDPOINT_ID            BIGINT not null
+        references APP.ENDPOINT,
+    FAILURE_WITH_RATELIMIT BIGINT not null,
+    ID                     BIGINT default GENERATED_BY_DEFAULT generated always as identity
+        primary key,
+    METRIC_DATE            DATE   not null,
+    PAGE_VIEW              BIGINT not null
+);
+
+create table APP.SYSTEM_METRIC
+(
+    CPU_USAGE_PERCENT    DOUBLE    not null,
+    DISK_USAGE_PERCENT   DOUBLE    not null,
+    ID                   BIGINT default GENERATED_BY_DEFAULT generated always as identity
+        primary key,
+    MEMORY_USAGE_PERCENT DOUBLE    not null,
+    TIMESTAMP            TIMESTAMP not null
+);
+


### PR DESCRIPTION
## Here are the key takeaways from this PR

### 1. Apply Flyway migration

### 2. Downgrading the Derby Database version

> We downgraded because the latest derby version supported by flyway is 10.15.
