### PR TITLE
Resolved error where springdog agent requests were not filtered in RatelimitInterceptor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 rootPackageName=org.easypeelsecurity
-springDogVersion=0.0.1
+springDogVersion=0.0.2
 # Gradle plugins versions
 mavenPublishVersion=0.29.0
 shadowVersion=8.1.6

--- a/springdog-project/springdog-manager/build.gradle
+++ b/springdog-project/springdog-manager/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(":springdog-project:springdog-notification")
     implementation project(":springdog-project:springdog-domain")
     implementation project(":springdog-project:springdog-shared")
+    compileOnly project(":springdog-project:springdog-agent")
     implementation "commons-io:commons-io:2.16.1"
     implementation "com.github.oshi:oshi-core:6.6.2"
 }

--- a/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/config/SpringdogHandlerInterceptorApplier.java
+++ b/springdog-project/springdog-manager/src/main/java/org/easypeelsecurity/springdog/manager/config/SpringdogHandlerInterceptorApplier.java
@@ -52,7 +52,7 @@ public class SpringdogHandlerInterceptorApplier implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(new RatelimitInterceptor(this.endpointService, this.springdogProperties));
+    registry.addInterceptor(new RatelimitInterceptor(this.endpointService));
     registry.addInterceptor(new AgentExternalAccessInterceptor(this.springdogProperties));
     registry.addInterceptor(
         new RequestTimingInterceptor(this.springdogProperties, this.slowResponseEmailNotificationManager));


### PR DESCRIPTION
Resolved error where springdog agent requests were not filtered in RatelimitInterceptor

This was causing an error when uploading access statistics because it tried to upload up to /springdog/ path.